### PR TITLE
Npm install Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/jonathanong/bigpipe-example/issues"
   },
   "dependencies": {
-    "co": "^3.0.1",
+    "co": "^4.6.0",
     "koa": ">= 0.1.2",
     "koa-static": "*",
     "koa-favicon": "*",


### PR DESCRIPTION
Hi,When running "npm install",it shows the following errors.

fatal : component at "/Users/lifeifei/Documents/node/bigpipe-example-master/client/boot"'s name does not match the component's.
ERR! Failed at the bigpipe-example@0.1.0 postinstall script 'make'. 
So can you help me figure out the reasons.Thanks.

My platform informations:
node v6.1.0, npm  v3.8.6, Darwin 15.3.0
